### PR TITLE
feat: support faculty selection in admin management

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -60,7 +60,8 @@ $admins_query = mysqli_query($conn, "SELECT a.*, r.name AS role_name, s.name AS 
                                 data-phone="<?php echo $admin['phone']; ?>"
                                 data-gender="<?php echo $admin['gender']; ?>"
                                 data-role="<?php echo $admin['role']; ?>"
-                                data-school="<?php echo $admin['school']; ?>">
+                                data-school="<?php echo $admin['school'] ?? 0; ?>"
+                                data-faculty="<?php echo $admin['faculty'] ?? 0; ?>">
                                 <i class="bx bx-edit-alt me-1"></i> Edit
                               </a>
                               <a class="dropdown-item deleteAdmin" href="javascript:void(0);" data-id="<?php echo $admin['id']; ?>">
@@ -134,13 +135,19 @@ $admins_query = mysqli_query($conn, "SELECT a.*, r.name AS role_name, s.name AS 
               <div class="col-md-6 mb-3">
                 <label for="school" class="form-label">School</label>
                 <select name="school" id="school" class="form-select">
-                  <option value="0">Select School</option>
+                  <option value="0">All Schools</option>
                   <?php while($school = mysqli_fetch_array($schools_query)) { ?>
                     <option value="<?php echo $school['id']; ?>"><?php echo $school['name']; ?></option>
                   <?php } ?>
                 </select>
               </div>
               <div class="col-md-6 mb-3">
+                <label for="faculty" class="form-label">Faculty</label>
+                <select name="faculty" id="faculty" class="form-select">
+                  <option value="0">All Faculties</option>
+                </select>
+              </div>
+              <div class="col-12 mb-3" id="password_field">
                 <label for="password" class="form-label">Password</label>
                 <input type="password" name="password" class="form-control">
               </div>

--- a/model/admin.php
+++ b/model/admin.php
@@ -13,7 +13,9 @@ if (isset($_POST['admin_manage'])) {
   $gender = mysqli_real_escape_string($conn, $_POST['gender']);
   $role = intval($_POST['role']);
   $school = intval($_POST['school']);
+  $faculty = intval($_POST['faculty']);
   $school_sql = $school > 0 ? $school : 'NULL';
+  $faculty_sql = $faculty > 0 ? $faculty : 'NULL';
 
   if ($admin_id == 0) {
     $password = md5($_POST['password']);
@@ -22,7 +24,7 @@ if (isset($_POST['admin_manage'])) {
       $statusRes = "denied";
       $messageRes = "A user has been associated with this email. <br> Please try again with another email!";
     } else {
-      mysqli_query($conn, "INSERT INTO admins (first_name, last_name, email, phone, gender, role, school, password) VALUES ('$first_name', '$last_name', '$email', '$phone', '$gender', $role, $school_sql, '$password')");
+      mysqli_query($conn, "INSERT INTO admins (first_name, last_name, email, phone, gender, role, school, faculty, password) VALUES ('$first_name', '$last_name', '$email', '$phone', '$gender', $role, $school_sql, $faculty_sql, '$password')");
       if (mysqli_affected_rows($conn) >= 1) {
         $statusRes = "success";
         $messageRes = "Admin successfully added!";
@@ -37,7 +39,7 @@ if (isset($_POST['admin_manage'])) {
       $password = md5($_POST['password']);
       $password_sql = ", password = '$password'";
     }
-    mysqli_query($conn, "UPDATE admins SET first_name = '$first_name', last_name = '$last_name', email = '$email', phone = '$phone', gender = '$gender', role = $role, school = $school_sql" . $password_sql . " WHERE id = $admin_id");
+    mysqli_query($conn, "UPDATE admins SET first_name = '$first_name', last_name = '$last_name', email = '$email', phone = '$phone', gender = '$gender', role = $role, school = $school_sql, faculty = $faculty_sql" . $password_sql . " WHERE id = $admin_id");
     if (mysqli_affected_rows($conn) >= 1) {
       $statusRes = "success";
       $messageRes = "Admin successfully updated!";


### PR DESCRIPTION
## Summary
- add faculty selection to admin create/edit modal
- hide password field during admin edits and make it full width
- allow selecting "All" schools or faculties and persist faculty on backend

## Testing
- `php -l admin.php`
- `php -l model/admin.php`
- `node --check model/functions/admins.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7574b1f10832896e7b7f0408bf4b7