### PR TITLE
Ensure closed status for materials and add action icons

### DIFF
--- a/course_materials.php
+++ b/course_materials.php
@@ -16,7 +16,7 @@ if ($admin_role == 5) {
     $faculties_query = mysqli_query($conn, "SELECT id, name FROM faculties WHERE status = 'active' AND school_id = $admin_school ORDER BY name");
     $depts_query = mysqli_query($conn, "SELECT id, name FROM depts WHERE status = 'active' AND school_id = $admin_school ORDER BY name");
   }
-  $material_sql = "SELECT m.*, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE m.school_id = $admin_school";
+  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE m.school_id = $admin_school";
   if ($admin_faculty != 0) {
     $material_sql .= " AND d.faculty_id = $admin_faculty";
   }
@@ -25,7 +25,7 @@ if ($admin_role == 5) {
   $schools_query = mysqli_query($conn, "SELECT id, name FROM schools WHERE status = 'active' ORDER BY name");
   $faculties_query = mysqli_query($conn, "SELECT id, name FROM faculties WHERE status = 'active' ORDER BY name");
   $depts_query = mysqli_query($conn, "SELECT id, name FROM depts WHERE status = 'active' ORDER BY name");
-  $material_sql = "SELECT m.*, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id GROUP BY m.id ORDER BY m.created_at DESC";
+  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id GROUP BY m.id ORDER BY m.created_at DESC";
 }
 $materials_query = mysqli_query($conn, $material_sql);
 ?>
@@ -110,8 +110,8 @@ $materials_query = mysqli_query($conn, $material_sql);
                               <i class="bx bx-dots-vertical-rounded"></i>
                             </button>
                             <div class="dropdown-menu">
-                              <a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="<?php echo $mat['id']; ?>" data-status="<?php echo $mat['status']; ?>">
-                                <?php if($mat['status']=='open') { ?>
+                              <a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="<?php echo $mat['id']; ?>" data-status="<?php echo $mat['db_status']; ?>">
+                                <?php if($mat['db_status']=='open') { ?>
                                   <i class="bx bx-lock me-1"></i> Close Material
                                 <?php } else { ?>
                                   <i class="bx bx-lock-open me-1"></i> Open Material

--- a/course_materials.php
+++ b/course_materials.php
@@ -111,7 +111,11 @@ $materials_query = mysqli_query($conn, $material_sql);
                             </button>
                             <div class="dropdown-menu">
                               <a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="<?php echo $mat['id']; ?>" data-status="<?php echo $mat['status']; ?>">
-                                <?php echo $mat['status']=='open' ? 'Close Material' : 'Open Material'; ?>
+                                <?php if($mat['status']=='open') { ?>
+                                  <i class="bx bx-lock me-1"></i> Close Material
+                                <?php } else { ?>
+                                  <i class="bx bx-lock-open me-1"></i> Open Material
+                                <?php } ?>
                               </a>
                             </div>
                           </div>

--- a/course_materials.php
+++ b/course_materials.php
@@ -16,7 +16,7 @@ if ($admin_role == 5) {
     $faculties_query = mysqli_query($conn, "SELECT id, name FROM faculties WHERE status = 'active' AND school_id = $admin_school ORDER BY name");
     $depts_query = mysqli_query($conn, "SELECT id, name FROM depts WHERE status = 'active' AND school_id = $admin_school ORDER BY name");
   }
-  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE m.school_id = $admin_school";
+  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status, CASE WHEN m.due_date < NOW() THEN 1 ELSE 0 END AS due_passed FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE m.school_id = $admin_school";
   if ($admin_faculty != 0) {
     $material_sql .= " AND d.faculty_id = $admin_faculty";
   }
@@ -25,7 +25,7 @@ if ($admin_role == 5) {
   $schools_query = mysqli_query($conn, "SELECT id, name FROM schools WHERE status = 'active' ORDER BY name");
   $faculties_query = mysqli_query($conn, "SELECT id, name FROM faculties WHERE status = 'active' ORDER BY name");
   $depts_query = mysqli_query($conn, "SELECT id, name FROM depts WHERE status = 'active' ORDER BY name");
-  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id GROUP BY m.id ORDER BY m.created_at DESC";
+  $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status, CASE WHEN m.due_date < NOW() THEN 1 ELSE 0 END AS due_passed FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id GROUP BY m.id ORDER BY m.created_at DESC";
 }
 $materials_query = mysqli_query($conn, $material_sql);
 ?>
@@ -61,7 +61,7 @@ $materials_query = mysqli_query($conn, $material_sql);
                     </select>
                   </div>
                   <div class="col-md-4">
-                    <select name="faculty" id="faculty" class="form-select">
+                    <select name="faculty" id="faculty" class="form-select" <?php if($admin_role == 5 && $admin_faculty != 0) echo 'disabled'; ?>>
                       <?php if(!($admin_role == 5 && $admin_faculty != 0)) { ?>
                         <option value="0">All Faculties</option>
                       <?php } ?>
@@ -105,6 +105,7 @@ $materials_query = mysqli_query($conn, $material_sql);
                         <td><span class="fw-bold badge bg-label-<?php echo $mat['status']=='open' ? 'success' : 'danger'; ?>"><?php echo ucfirst($mat['status']); ?></span></td>
                         <td><?php echo date('M d, Y', strtotime($mat['due_date'])); ?></td>
                         <td>
+                          <?php if(!$mat['due_passed']) { ?>
                           <div class="dropstart">
                             <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown" aria-expanded="true">
                               <i class="bx bx-dots-vertical-rounded"></i>
@@ -119,6 +120,7 @@ $materials_query = mysqli_query($conn, $material_sql);
                               </a>
                             </div>
                           </div>
+                          <?php } ?>
                         </td>
                       </tr>
                       <?php } ?>

--- a/model/functions/materials.js
+++ b/model/functions/materials.js
@@ -89,7 +89,7 @@ $(document).ready(function () {
               '<i class="bx bx-dots-vertical-rounded"></i></button>' +
               '<div class="dropdown-menu">' +
               '<a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="' + mat.id + '" data-status="' + mat.status + '">' +
-              (mat.status === 'open' ? 'Close Material' : 'Open Material') + '</a>' +
+              (mat.status === 'open' ? '<i class="bx bx-lock me-1"></i> Close Material' : '<i class="bx bx-lock-open me-1"></i> Open Material') + '</a>' +
               '</div></div></td>' +
               '</tr>';
             tbody.append(row);

--- a/model/functions/materials.js
+++ b/model/functions/materials.js
@@ -26,6 +26,7 @@ $(document).ready(function () {
             $fac.append('<option value="' + fac.id + '">' + fac.name + '</option>');
           });
         }
+        $fac.prop('disabled', res.restrict_faculty);
         var selected = res.restrict_faculty && res.faculties.length > 0 ? res.faculties[0].id : '0';
         $fac.val(selected).trigger('change.select2');
       }
@@ -77,6 +78,16 @@ $(document).ready(function () {
         tbody.empty();
         if (res.status === 'success' && res.materials) {
           $.each(res.materials, function (i, mat) {
+            var actionHtml = '';
+            if (!mat.due_passed) {
+              actionHtml = '<div class="dropstart">' +
+                '<button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown" aria-expanded="true">' +
+                '<i class="bx bx-dots-vertical-rounded"></i></button>' +
+                '<div class="dropdown-menu">' +
+                '<a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="' + mat.id + '" data-status="' + mat.db_status + '">' +
+                (mat.db_status === 'open' ? '<i class="bx bx-lock me-1"></i> Close Material' : '<i class="bx bx-lock-open me-1"></i> Open Material') + '</a>' +
+                '</div></div>';
+            }
             var row = '<tr>' +
               '<td class="text-uppercase"><strong>' + mat.title + ' (' + mat.course_code + ')</strong></td>' +
               '<td>₦ ' + Number(mat.price).toLocaleString() + '</td>' +
@@ -84,13 +95,7 @@ $(document).ready(function () {
               '<td>' + mat.qty_sold + '</td>' +
               '<td><span class="fw-bold badge bg-label-' + (mat.status === 'open' ? 'success' : 'danger') + '">' + mat.status.charAt(0).toUpperCase() + mat.status.slice(1) + '</span></td>' +
               '<td>' + mat.due_date + '</td>' +
-              '<td><div class="dropstart">' +
-              '<button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown" aria-expanded="true">' +
-              '<i class="bx bx-dots-vertical-rounded"></i></button>' +
-              '<div class="dropdown-menu">' +
-              '<a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="' + mat.id + '" data-status="' + mat.db_status + '">' +
-              (mat.db_status === 'open' ? '<i class="bx bx-lock me-1"></i> Close Material' : '<i class="bx bx-lock-open me-1"></i> Open Material') + '</a>' +
-              '</div></div></td>' +
+              '<td>' + actionHtml + '</td>' +
               '</tr>';
             tbody.append(row);
           });

--- a/model/functions/materials.js
+++ b/model/functions/materials.js
@@ -88,8 +88,8 @@ $(document).ready(function () {
               '<button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown" aria-expanded="true">' +
               '<i class="bx bx-dots-vertical-rounded"></i></button>' +
               '<div class="dropdown-menu">' +
-              '<a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="' + mat.id + '" data-status="' + mat.status + '">' +
-              (mat.status === 'open' ? '<i class="bx bx-lock me-1"></i> Close Material' : '<i class="bx bx-lock-open me-1"></i> Open Material') + '</a>' +
+              '<a href="javascript:void(0);" class="dropdown-item toggleMaterial" data-id="' + mat.id + '" data-status="' + mat.db_status + '">' +
+              (mat.db_status === 'open' ? '<i class="bx bx-lock me-1"></i> Close Material' : '<i class="bx bx-lock-open me-1"></i> Open Material') + '</a>' +
               '</div></div></td>' +
               '</tr>';
             tbody.append(row);

--- a/model/materials.php
+++ b/model/materials.php
@@ -75,7 +75,7 @@ if(isset($_GET['fetch'])){
   }
 
   if($fetch == 'materials'){
-    $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE 1=1";
+    $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status, CASE WHEN m.due_date < NOW() THEN 1 ELSE 0 END AS due_passed FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE 1=1";
     if($admin_role == 5){
       $material_sql .= " AND m.school_id = $admin_school";
       if($admin_faculty != 0){
@@ -105,7 +105,8 @@ if(isset($_GET['fetch'])){
         'qty_sold' => $row['qty_sold'],
         'status' => $row['status'],
         'db_status' => $row['db_status'],
-        'due_date' => date('M d, Y', strtotime($row['due_date']))
+        'due_date' => date('M d, Y', strtotime($row['due_date'])),
+        'due_passed' => $row['due_passed'] == 1
       );
     }
     $statusRes = 'success';

--- a/model/materials.php
+++ b/model/materials.php
@@ -119,7 +119,7 @@ if(isset($_POST['toggle_id'])){
       $statusRes = 'error';
       $messageRes = 'Unauthorized';
     } else {
-      $new_status = ($manual_res['status'] == 'open') ? 'close' : 'open';
+      $new_status = ($manual_res['status'] == 'open') ? 'closed' : 'open';
       mysqli_query($conn, "UPDATE manuals SET status = '$new_status' WHERE id = $id");
       if(mysqli_affected_rows($conn) > 0){
         $statusRes = 'success';

--- a/model/materials.php
+++ b/model/materials.php
@@ -75,7 +75,7 @@ if(isset($_GET['fetch'])){
   }
 
   if($fetch == 'materials'){
-    $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.status, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE 1=1";
+    $material_sql = "SELECT m.id, m.title, m.course_code, m.price, m.due_date, IFNULL(SUM(b.price),0) AS revenue, COUNT(b.manual_id) AS qty_sold, CASE WHEN m.due_date < NOW() THEN 'closed' ELSE m.status END AS status, m.status AS db_status FROM manuals m LEFT JOIN manuals_bought b ON b.manual_id = m.id AND b.status='successful' LEFT JOIN depts d ON m.dept = d.id WHERE 1=1";
     if($admin_role == 5){
       $material_sql .= " AND m.school_id = $admin_school";
       if($admin_faculty != 0){
@@ -104,6 +104,7 @@ if(isset($_GET['fetch'])){
         'revenue' => $row['revenue'],
         'qty_sold' => $row['qty_sold'],
         'status' => $row['status'],
+        'db_status' => $row['db_status'],
         'due_date' => date('M d, Y', strtotime($row['due_date']))
       );
     }


### PR DESCRIPTION
## Summary
- Use `closed` status when toggling material availability
- Add lock icons to Open/Close material dropdown actions

## Testing
- `php -l course_materials.php`
- `php -l model/materials.php`
- `node --check model/functions/materials.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7584426008328aba962b785b5e8e3