### PR TITLE
Restrict student lookup to admin's school and faculty

### DIFF
--- a/students.php
+++ b/students.php
@@ -87,6 +87,12 @@ $admin_faculty = $admin_['faculty'] ?? 0;
                             <button type="submit" class="btn btn-secondary w-100 search_profile-btn">Search</button>
                           </div>
                         </div>
+                        <?php if ($admin_role == 5) { ?>
+                        <input type="hidden" name="admin_school" value="<?php echo $admin_school; ?>" />
+                        <?php if ($admin_faculty) { ?>
+                        <input type="hidden" name="admin_faculty" value="<?php echo $admin_faculty; ?>" />
+                        <?php } ?>
+                        <?php } ?>
                       </form>
                     </div>
                     <hr class="my-0" />
@@ -159,6 +165,12 @@ $admin_faculty = $admin_['faculty'] ?? 0;
                             <button type="submit" class="btn btn-secondary w-100 search_verify-btn">Search</button>
                           </div>
                         </div>
+                        <?php if ($admin_role == 5) { ?>
+                        <input type="hidden" name="admin_school" value="<?php echo $admin_school; ?>" />
+                        <?php if ($admin_faculty) { ?>
+                        <input type="hidden" name="admin_faculty" value="<?php echo $admin_faculty; ?>" />
+                        <?php } ?>
+                        <?php } ?>
                       </form>
                     </div>
                     <hr class="my-0" />


### PR DESCRIPTION
## Summary
- Pass admin school and faculty in student search forms when role is 5
- Validate student profile retrieval to ensure role-5 admins can only access students from their school and faculty

## Testing
- `php -l students.php`
- `php -l model/student.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7634a6268832883affd72248a7a12