### PR TITLE
Restrict faculty view for faculty-level admins

### DIFF
--- a/model/functions/schools.js
+++ b/model/functions/schools.js
@@ -423,6 +423,8 @@ function populateFacTable(Facs, school_id, tableId) {
                                                         <td>
                                                                 <i class="text-primary me-3"></i> <strong>${fac.name}</strong>
                                                         </td>
+                                                        <td>${fac.total_students}</td>
+                                                        <td>${fac.total_hocs}</td>
                                                         <td>${fac.total_departments}</td>
                                                         <td><span class="fw-bold badge bg-label-${fac.status == 'active' ? 'success">Active' : 'danger">Deactivated'}</span></td>
                                                         <td>

--- a/partials/_sidebar.php
+++ b/partials/_sidebar.php
@@ -2,6 +2,7 @@
 // Get the current page name
 $current_page = basename($_SERVER['PHP_SELF']);
 $current_tab = isset($_GET['tab']) ? $_GET['tab'] : '';
+$admin_faculty = $admin_['faculty'] ?? 0;
 ?>
 
 <aside id="layout-menu" class="layout-menu menu-vertical menu bg-menu-theme">
@@ -44,11 +45,13 @@ $current_tab = isset($_GET['tab']) ? $_GET['tab'] : '';
             <div data-i18n="Schools">Schools</div>
           </a>
           <ul class="menu-sub">
+            <?php if ($admin_faculty == 0) { ?>
             <li class="menu-item <?php echo $current_page == 'school.php' && $current_tab == 'faculties' ? 'active' : ''; ?>">
               <a href="school.php?tab=faculties" class="menu-link">
                 <div data-i18n="Schools">Faculties</div>
               </a>
             </li>
+            <?php } ?>
             <li class="menu-item <?php echo $current_page == 'school.php' && $current_tab == 'departments' ? 'active' : ''; ?>">
               <a href="school.php?tab=departments" class="menu-link">
                 <div data-i18n="Schools">Departments</div>

--- a/school.php
+++ b/school.php
@@ -5,12 +5,20 @@ include('model/page_config.php');
 
 $admin_role = $_SESSION['nivas_adminRole'];
 $admin_school = $admin_['school'];
+$admin_faculty = $admin_['faculty'] ?? 0;
 $admin_school_name = '';
 if ($admin_role == 5) {
   $admin_school_name = mysqli_fetch_array(mysqli_query($conn, "SELECT name FROM schools WHERE id = $admin_school"))[0];
-  if (!isset($_GET['tab']) || ($_GET['tab'] != 'departments' && $_GET['tab'] != 'faculties')) {
-    header('Location: school.php?tab=departments');
-    exit();
+  if ($admin_faculty) {
+    if (!isset($_GET['tab']) || $_GET['tab'] != 'departments') {
+      header('Location: school.php?tab=departments');
+      exit();
+    }
+  } else {
+    if (!isset($_GET['tab']) || ($_GET['tab'] != 'departments' && $_GET['tab'] != 'faculties')) {
+      header('Location: school.php?tab=departments');
+      exit();
+    }
   }
 }
 
@@ -66,11 +74,13 @@ if ($admin_role == 5) {
                         class="bx bxs-school me-1"></i> Schools</button>
                   </li>
                   <?php } ?>
+                  <?php if ($admin_faculty == 0) { ?>
                   <li class="nav-item">
                     <button type="button" class="nav-link <?php echo ($current_tab == 'faculties') ? 'active' : ''; ?>" role="tab" data-bs-toggle="tab"
                       data-bs-target="#navs-top-faculties" aria-controls="navs-top-faculties" aria-selected="false"><i
                         class='bx bxs-book-alt me-1'></i>Faculties</button>
                   </li>
+                  <?php } ?>
                   <li class="nav-item">
                     <button type="button" class="nav-link <?php echo ($current_tab == 'departments') ? 'active' : ''; ?>" role="tab" data-bs-toggle="tab"
                       data-bs-target="#navs-top-departments" aria-controls="navs-top-departments" aria-selected="false"><i
@@ -101,6 +111,7 @@ if ($admin_role == 5) {
                     </div>
                   </div>
 <?php } ?>
+                  <?php if ($admin_faculty == 0) { ?>
                   <div class="card mb-4 tab-pane fade <?php echo ($current_tab == 'faculties') ? 'active show' : ''; ?>" id="navs-top-faculties" role="tabpanel">
                     <?php if ($admin_role != 5) { ?>
                     <div class="card-header">
@@ -129,6 +140,8 @@ if ($admin_role == 5) {
                           <thead class="table-secondary">
                             <tr>
                               <th>Name</th>
+                              <th>Students</th>
+                              <th>HOC</th>
                               <th>Departments</th>
                               <th>Status</th>
                               <th>Actions</th>
@@ -141,6 +154,7 @@ if ($admin_role == 5) {
                       </div>
                     </div>
                   </div>
+                  <?php } ?>
 
                   <div class="card mb-4 tab-pane fade <?php echo ($current_tab == 'departments') ? 'active show' : ''; ?>" id="navs-top-departments" role="tabpanel">
                     <?php if ($admin_role != 5) { ?>
@@ -351,9 +365,11 @@ if ($admin_role == 5) {
     $(document).ready(function() {
       <?php if ($admin_role == 5) { ?>
         $('#school').html('<option value="<?php echo $admin_school; ?>"><?php echo $admin_school_name; ?></option>');
+        <?php if ($admin_faculty == 0) { ?>
         $('#faculty_school').html('<option value="<?php echo $admin_school; ?>"><?php echo $admin_school_name; ?></option>');
-        fetchDepts(<?php echo $admin_school; ?>);
         fetchFaculties(<?php echo $admin_school; ?>);
+        <?php } ?>
+        fetchDepts(<?php echo $admin_school; ?>);
       <?php } else { ?>
         fetchSchools();
         fetchSchools2();


### PR DESCRIPTION
## Summary
- Hide faculty management links for admins bound to a specific faculty
- Limit department queries to the admin's faculty and expose student/HOC counts in faculty data
- Display student and HOC totals on the faculties table

## Testing
- `php -l model/getInfo.php`
- `php -l school.php`
- `php -l partials/_sidebar.php`
- `node --check model/functions/schools.js`


------
https://chatgpt.com/codex/tasks/task_e_68a765b6947c832892376f07fb6b7aef