### PR TITLE
Add show password toggle to new admin form

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -147,9 +147,18 @@ $admins_query = mysqli_query($conn, "SELECT a.*, r.name AS role_name, s.name AS 
                   <option value="0">All Faculties</option>
                 </select>
               </div>
-              <div class="col-12 mb-3" id="password_field">
+              <div class="col-12 mb-3 form-password-toggle" id="password_field">
                 <label for="password" class="form-label">Password</label>
-                <input type="password" name="password" class="form-control">
+                <div class="input-group input-group-merge">
+                  <input
+                    type="password"
+                    name="password"
+                    class="form-control"
+                    placeholder="&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;&#xb7;"
+                    aria-describedby="password"
+                  >
+                  <span class="input-group-text cursor-pointer"><i class="bx bx-hide"></i></span>
+                </div>
               </div>
             </div>
           </div>

--- a/school.php
+++ b/school.php
@@ -276,7 +276,7 @@ if ($admin_role == 5) {
                   </div>
                   <div class="mb-3">
                     <label for="faculty" class="form-label">Faculty</label>
-                    <select name="faculty" class="form-select" required>
+                    <select name="faculty" class="form-select no-select2" required>
                       <option value="">Select faculty</option>
                     </select>
                   </div>
@@ -373,7 +373,7 @@ if ($admin_role == 5) {
       <?php } else { ?>
         fetchSchools();
         fetchSchools2();
-        $('.form-select').select2({
+        $('.form-select').not('.no-select2').select2({
           theme: "bootstrap-5",
           width: $(this).data('width') ? $(this).data('width') : $(this).hasClass('w-100') ? '100%' : 'style',
           placeholder: $(this).data('placeholder'),


### PR DESCRIPTION
## Summary
- add form-password-toggle UI for admin password field
- prevent faculty dropdown in department modal from converting to Select2

## Testing
- `php -l admin.php`
- `php -l school.php`


------
https://chatgpt.com/codex/tasks/task_e_68c12bf8a7d08328b1ec6b6ee418783e