### PR TITLE
Hide save button for role 5 on student profile

### DIFF
--- a/students.php
+++ b/students.php
@@ -141,9 +141,11 @@ $admin_faculty = $admin_['faculty'] ?? 0;
                             </select>
                           </div>
                         </div>
+                        <?php if ($admin_role != 5) { ?>
                         <div class="mt-2">
                           <button type="submit" class="btn btn-primary me-2 profile-form-btn">Save changes</button>
                         </div>
+                        <?php } ?>
                       </form>
                     </div>
                     <!-- /Account -->


### PR DESCRIPTION
## Summary
- hide student profile save button for admins with role 5

## Testing
- `php -l students.php`


------
https://chatgpt.com/codex/tasks/task_e_68c12fb9db2c8328ace81a3375cf7ac6