### PR TITLE
Define admin role variable across missing pages

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -3,6 +3,8 @@ session_start();
 include('model/config.php');
 include('model/page_config.php');
 
+$admin_role = $_SESSION['nivas_adminRole'];
+
 $roles_query = mysqli_query($conn, "SELECT id, name FROM admin_roles WHERE status = 'active'");
 $schools_query = mysqli_query($conn, "SELECT id, name FROM schools WHERE status = 'active'");
 $admins_query = mysqli_query($conn, "SELECT a.*, r.name AS role_name, s.name AS school_name FROM admins a LEFT JOIN admin_roles r ON a.role = r.id LEFT JOIN schools s ON a.school = s.id");

--- a/profile.php
+++ b/profile.php
@@ -3,6 +3,8 @@ session_start();
 include('model/config.php');
 include('model/page_config.php');
 
+$admin_role = $_SESSION['nivas_adminRole'];
+
 $profile_pic_path = file_exists("assets/images/users/$admin_image") ? "assets/images/users/$admin_image" : "assets/img/avatars/user.png";
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/tickets.php
+++ b/tickets.php
@@ -3,6 +3,8 @@ session_start();
 include('model/config.php');
 include('model/page_config.php');
 
+$admin_role = $_SESSION['nivas_adminRole'];
+
 ?>
 
 <!DOCTYPE html>

--- a/visitors.php
+++ b/visitors.php
@@ -3,6 +3,8 @@ session_start();
 include('model/config.php');
 include('model/page_config.php');
 
+$admin_role = $_SESSION['nivas_adminRole'];
+
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- define `$admin_role` from session on admin, profile, visitors, and tickets pages

## Testing
- `php -l admin.php profile.php tickets.php visitors.php`


------
https://chatgpt.com/codex/tasks/task_e_68c133d15cec8328961e9a068f066d37