### PR TITLE
Grant customer support access to student pages

### DIFF
--- a/model/page_config.php
+++ b/model/page_config.php
@@ -47,6 +47,7 @@ if ($_SESSION['nivas_adminRole'] == 1) {
   $customer_mgt_menu = True;
   $sch_mgt_menu = True;
   $public_mgt_menu = True;
+  $student_mgt_menu = True;
   $finance_mgt_menu = True;
   $resource_mgt_menu = True;
 } else if ($_SESSION['nivas_adminRole'] == 3) {


### PR DESCRIPTION
## Summary
- allow customer support role to see student pages by enabling student management menu for role 2

## Testing
- `php -l model/page_config.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1659d09888328affd745d4b68a198